### PR TITLE
Fix test suite. Use StreamTrackIds instead of nonexisting FileTrackIds.

### DIFF
--- a/spec/app/stream_track_ids_spec.rb
+++ b/spec/app/stream_track_ids_spec.rb
@@ -1,8 +1,8 @@
-require 'spotify_to_mp3/app/file_track_ids'
+require 'spotify_to_mp3/app/stream_track_ids'
 require 'tempfile'
 
 module SpotifyToMp3
-  describe App::FileTrackIds do
+  describe App::StreamTrackIds do
     it "reads lines" do
       open_test_file("1\n2\n3") do |ids|
         ids.count.should == 3
@@ -25,7 +25,7 @@ module SpotifyToMp3
       Tempfile.open('tracks') do |file|
         file.write(content)
         file.rewind
-        yield App::FileTrackIds.new(file)
+        yield App::StreamTrackIds.new(file)
       end
     end
   end


### PR DESCRIPTION
Hey,

I was getting that error when trying to run specs with `rspec spec/`:

```
tomaszgieres@kajtek:~/Projects/spotify-to-mp3(master⚡) » rspec spec
/Users/tomaszgieres/Projects/spotify-to-mp3/spec/app/file_track_ids_spec.rb:1:in `require': cannot load such file -- spotify_to_mp3/app/file_track_ids (LoadError)
        from /Users/tomaszgieres/Projects/spotify-to-mp3/spec/app/file_track_ids_spec.rb:1:in `<top (required)>'
        from /Users/tomaszgieres/.rvm/gems/ruby-1.9.3-p448/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `load'
        from /Users/tomaszgieres/.rvm/gems/ruby-1.9.3-p448/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `block in load_spec_files'
        from /Users/tomaszgieres/.rvm/gems/ruby-1.9.3-p448/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `each'
        from /Users/tomaszgieres/.rvm/gems/ruby-1.9.3-p448/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `load_spec_files'
        from /Users/tomaszgieres/.rvm/gems/ruby-1.9.3-p448/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:22:in `run'
        from /Users/tomaszgieres/.rvm/gems/ruby-1.9.3-p448/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:80:in `run'
        from /Users/tomaszgieres/.rvm/gems/ruby-1.9.3-p448/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:17:in `block in autorun'
```

The spec suite runs correctly now and everything is green.
